### PR TITLE
Vscode support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"samuelcolvin.jinjahtml"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+	"editor.wordWrap": "on",
+	"editor.wrappingIndent": "indent",
+	"files.associations": {
+		"**/*.yml": "ansible"
+	},
+	"files.insertFinalNewline": true,
+	"telemetry.enableCrashReporter": false
+}


### PR DESCRIPTION
Note: I need to rehost microsoft's old ansible extension on the microsoft store, as the new one is ass in that it has native dependencies and individual setup. The old one just worked. It has some bugs related to the run in ansible via ssh config menu items, but i just wanted the ansible aware yml syntax highlighting. 

For now you can get it here: https://github.com/tgstation-operations/ansible-vscode/releases and side load it via the `...` menu on the extentions page.