### PR TITLE
Fix docker-ingress-router not detecting docker wasn't ready

### DIFF
--- a/roles/docker_swarm_snat_fix/files/docker-ingress-router.sh
+++ b/roles/docker_swarm_snat_fix/files/docker-ingress-router.sh
@@ -45,10 +45,10 @@ quit() {
 detect_ingress() {
   read INGRESS_SUBNET INGRESS_DEFAULT_GATEWAY \
     < <(docker inspect ingress --format '{{(index .IPAM.Config 0).Subnet}} {{index (split (index .Containers "ingress-sbox").IPv4Address "/") 0}}')
-    
-  [ -n"$INGRESS_SUBNET" ] && [ -n"$INGRESS_DEFAULT_GATEWAY" ] && return 0
-  
-  return 1
+  if [ -z "$INGRESS_SUBNET" ] || [ -z "$INGRESS_DEFAULT_GATEWAY" ]; then
+    return 1
+  fi
+  return 0
 }
 
 usage() {


### PR DESCRIPTION
It would detect blank docker node network ips, then try and use them in subnet masks